### PR TITLE
Clean up test fixtures and test if persistent credentials missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ dependencies = [
 all = "pytest . {args}"
 cov = "pytest . --cov=src/eeauth {args}"
 
+[tool.pytest.ini_options]
+markers = [
+    "missing_registry: mark test as requiring a missing registry file",
+    "missing_credentials: mark test as requiring missing persistent credentials",
+]
+
 [tool.ruff]
 select = ["E", "I", "F", "B", "FA", "UP", "PT", "Q", "RET", "SIM", "PERF"]
 fix = true

--- a/src/eeauth/__init__.py
+++ b/src/eeauth/__init__.py
@@ -10,7 +10,12 @@ from .api import (
     remove_user,
     reset,
 )
-from .exceptions import NotInitializedError, UnknownUserError, UserNotFoundError
+from .exceptions import (
+    NotAuthenticatedError,
+    NotInitializedError,
+    UnknownUserError,
+    UserNotFoundError,
+)
 
 __version__ = "0.1.0"
 
@@ -22,6 +27,7 @@ __all__ = [
     "get_default_user",
     "reset",
     "NotInitializedError",
+    "NotAuthenticatedError",
     "UserNotFoundError",
     "UnknownUserError",
 ]

--- a/src/eeauth/api.py
+++ b/src/eeauth/api.py
@@ -47,7 +47,7 @@ def get_initialized_user() -> User:
     """
     credentials = ee.data._credentials
     if credentials is None:
-        raise NotInitializedError("Earth Engine is not initialized.")
+        raise NotInitializedError()
 
     registry = UserRegistry.open()
     return registry.find_user(refresh_token=credentials.refresh_token)

--- a/src/eeauth/cli.py
+++ b/src/eeauth/cli.py
@@ -7,7 +7,7 @@ from .api import (
     list_users,
     remove_user,
 )
-from .exceptions import UnknownUserError, UserNotFoundError
+from .exceptions import NotAuthenticatedError, UnknownUserError, UserNotFoundError
 from .user_registry import UserRegistry
 
 
@@ -15,7 +15,7 @@ from .user_registry import UserRegistry
 @click.version_option()
 def cli():
     """Manage Earth Engine authentication."""
-    click.echo("")
+    click.echo("")  # pragma: no cover
 
 
 @cli.command(name="authenticate")
@@ -78,5 +78,5 @@ def _is_default_user(name: str) -> bool:
     """Check if a user's name matches the default user."""
     try:
         return get_default_user().name == name
-    except UnknownUserError:
+    except (UnknownUserError, NotAuthenticatedError):
         return False

--- a/src/eeauth/exceptions.py
+++ b/src/eeauth/exceptions.py
@@ -21,4 +21,21 @@ class UnknownUserError(ValueError):
 class NotInitializedError(ValueError):
     """Earth Engine has not been initialized."""
 
-    pass
+    def __init__(self):
+        msg = (
+            "Earth Engine is not initialized. "
+            "Run `ee.Initialize()` or `ee.Initialize.as_user( ... )` to initialize."
+        )
+        super().__init__(msg)
+
+
+class NotAuthenticatedError(ValueError):
+    """Earth Engine has not been authenticated, so no persistent credentials exist."""
+
+    def __init__(self):
+        msg = (
+            "No persistent credentials could be found. "
+            "Run `ee.Authenticate()` or `ee.Authenticate.as_user( ... )` to "
+            "authenticate an account."
+        )
+        super().__init__(msg)

--- a/src/eeauth/user_registry.py
+++ b/src/eeauth/user_registry.py
@@ -10,7 +10,7 @@ import ee
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from pydantic import BaseModel
 
-from .exceptions import UnknownUserError, UserNotFoundError
+from .exceptions import NotAuthenticatedError, UnknownUserError, UserNotFoundError
 
 
 def get_registry_path() -> Path:
@@ -40,7 +40,12 @@ class Credentials(BaseModel):
     @classmethod
     def from_persistent_credentials(cls) -> Credentials:
         """Create credentials from the persistent Earth Engine credentials."""
-        return cls(**ee.oauth.get_credentials_arguments())
+        try:
+            args = ee.oauth.get_credentials_arguments()
+        except FileNotFoundError:
+            raise NotAuthenticatedError() from None
+
+        return cls(**args)
 
 
 class User(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,12 +4,20 @@ import pytest
 import eeauth
 
 
-def test_builds_missing_registry(missing_registry):
+@pytest.mark.missing_registry()
+def test_missing_registry():
     """Test that the registry is built if it doesn't exist."""
     assert eeauth.list_users() == []
 
 
-def test_activate(registry):
+@pytest.mark.missing_credentials()
+def test_missing_credentials():
+    """Test that NotAuthenticatedError is raised when credentials are missing."""
+    with pytest.raises(eeauth.NotAuthenticatedError):
+        eeauth.get_default_user()
+
+
+def test_activate():
     """Test that activating a user sets the default user."""
     eeauth.activate_user("extra_user")
     default_user = eeauth.get_default_user()
@@ -21,7 +29,7 @@ def test_activate(registry):
     assert default_user.name == "default_user"
 
 
-def test_get_initialized_user(registry):
+def test_get_initialized_user():
     """Test that the initialized user is returned."""
     with pytest.raises(eeauth.NotInitializedError):
         eeauth.get_initialized_user()
@@ -31,7 +39,7 @@ def test_get_initialized_user(registry):
     assert initialized_user.name == "default_user"
 
 
-def test_initialize_as_user(registry):
+def test_initialize_as_user():
     """Test that ee.Initialize.as_user sets the requested user."""
     # ee.Initialize is mocked, so we need to call the wrapper directly
     eeauth.initialize("extra_user")
@@ -41,7 +49,7 @@ def test_initialize_as_user(registry):
     assert eeauth.get_initialized_user().name == "default_user"
 
 
-def test_list_users(registry):
+def test_list_users():
     """Test that the registry is read and users are returned."""
     users = eeauth.list_users()
     user_names = [user.name for user in users]
@@ -50,7 +58,7 @@ def test_list_users(registry):
     assert user_names == ["default_user", "extra_user"]
 
 
-def test_remove_user(registry):
+def test_remove_user():
     """Test that a user is removed from the registry."""
     user = eeauth.list_users()[1]
 
@@ -60,7 +68,7 @@ def test_remove_user(registry):
     assert user.name not in [user.name for user in users]
 
 
-def test_authenticate(registry):
+def test_authenticate():
     """Test that a user is added to the registry when authenticated."""
     eeauth.authenticate("test_user3")
 
@@ -69,7 +77,7 @@ def test_authenticate(registry):
     assert "test_user3" in [user.name for user in users]
 
 
-def test_reset(registry):
+def test_reset():
     """Test that the registry is reset to an empty state."""
     eeauth.reset()
     assert len(eeauth.list_users()) == 0
@@ -78,7 +86,7 @@ def test_reset(registry):
 @pytest.mark.parametrize(
     "check_method", [eeauth.activate_user, eeauth.remove_user, eeauth.initialize]
 )
-def test_usernotfound(check_method, registry):
+def test_usernotfound(check_method):
     """Test that UserNotFoundError is raised when a user is not found."""
     with pytest.raises(eeauth.UserNotFoundError):
         check_method("non_existent_user")
@@ -87,7 +95,7 @@ def test_usernotfound(check_method, registry):
 @pytest.mark.parametrize(
     "check_method", [eeauth.get_default_user, eeauth.get_initialized_user]
 )
-def test_unknownuser(check_method, registry):
+def test_unknownuser(check_method):
     """Test for UnknownUserError when the default/initialized user is missing."""
     ee.Initialize()
     user_to_remove = check_method()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,32 +9,32 @@ def runner():
     return CliRunner()
 
 
-def test_activate(runner, registry):
+def test_activate(runner):
     result = runner.invoke(cli.activate, ["extra_user"])
     assert result.exit_code == 0
     assert "Activated `extra_user`" in result.output
 
 
-def test_remove(runner, registry):
+def test_remove(runner):
     result = runner.invoke(cli.remove, ["extra_user"])
     assert result.exit_code == 0
     assert "Removed `extra_user`" in result.output
 
 
 @pytest.mark.parametrize("check_command", [cli.activate, cli.remove])
-def test_user_not_found(check_command, runner, registry):
+def test_user_not_found(check_command, runner):
     result = runner.invoke(check_command, ["non_existent_user"])
     assert result.exit_code == 0
     assert "User `non_existent_user` not found in the registry." in result.output
 
 
-def test_list_command(runner, registry):
+def test_list_command(runner):
     result = runner.invoke(cli.list_command)
     assert result.exit_code == 0
     assert "extra_user" in result.output
 
 
-def test_authenticate_command(runner, registry):
+def test_authenticate_command(runner):
     result = runner.invoke(cli.authenticate_command, ["test_user_3"])
     assert result.exit_code == 0
     assert "Authenticated `test_user_3`" in result.output
@@ -45,7 +45,7 @@ def test_authenticate_command(runner, registry):
     assert "Cancelling" in result.output
 
 
-def test_mark_default_user(runner, registry):
+def test_mark_default_user(runner):
     """When listing users, make sure the default user is marked with *."""
     result = runner.invoke(cli.list_command)
     assert result.exit_code == 0
@@ -55,3 +55,10 @@ def test_mark_default_user(runner, registry):
     result = runner.invoke(cli.list_command)
     assert result.exit_code == 0
     assert "*" not in result.output
+
+
+@pytest.mark.missing_credentials()
+def test_missing_credentials(runner):
+    """Test that missing credentials do not prevent checking the default user."""
+    result = runner.invoke(cli.list_command)
+    assert result.exit_code == 0


### PR DESCRIPTION
This covers an edge case where the persistent Earth Engine credentials do not exist when they are accessed by `eeauth`. In that case, the API will raise a `NotAuthenticatedError`. The CLI will only need to read from the persistent credentials to provide info on the default user, so in this case it will just be treated as a non-existent user.

The other major change was refactoring the registry and credentials test fixtures to create empty paths based on `pytest` marks, which allows them to be auto-used for every test.