### PR TITLE
Pin to pydantic V2 to fix validation error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 dependencies = [
     "earthengine-api",
     "click",
-    "pydantic",
+    "pydantic==2.*",
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #12 

Pydantic V1 disallowed private attrs unless specifically defined in the model config. This breaks UserRegistry which tries to set _init_users on enter. This can be fixed by adding an `underscore_attrs_are_private` config option, but that's been deprecated in V2. Rather than adding a hacky solution to try and satisfy both versions, I'm just pinning.