### PR TITLE
Set default auth modes for API and CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     "notebook",
 ]
 dependencies = [
-    "earthengine-api",
+    "earthengine-api>=0.1.317",
     "click",
     "pydantic==2.*",
 ]

--- a/src/eeauth/api.py
+++ b/src/eeauth/api.py
@@ -65,6 +65,14 @@ def get_default_user() -> User:
 def initialize(name: str, **kwargs) -> None:
     """
     Initialize Earth Engine using the credentials of the registered user.
+
+    Parameters
+    ----------
+    name : str
+        The name of the user to initialize. This name is used locally, and does not
+        need to match the associated Google account.
+    kwargs
+        Keyword arguments passed to `ee.Initialize`, such as `project`.
     """
     registry = UserRegistry.open()
     user = registry.get_user(name)
@@ -72,7 +80,7 @@ def initialize(name: str, **kwargs) -> None:
     ee.Initialize(credentials=credentials, **kwargs)
 
 
-def authenticate(name: str, auth_mode: str = "notebook", **kwargs) -> None:
+def authenticate(name: str, **kwargs) -> None:
     """
     Authenticate Earth Engine and store the credentials for the registered user.
 
@@ -81,8 +89,10 @@ def authenticate(name: str, auth_mode: str = "notebook", **kwargs) -> None:
     name : str
         The name of the user to authenticate. This name is used locally, and does not
         need to match the associated Google account.
+    kwargs
+        Keyword arguments passed to `ee.Authenticate`, such as `auth_mode`.
     """
-    ee.Authenticate(auth_mode=auth_mode, **kwargs)
+    ee.Authenticate(**kwargs)
     user = User.from_persistent_credentials(name=name)
 
     with UserRegistry.open() as registry:

--- a/src/eeauth/cli.py
+++ b/src/eeauth/cli.py
@@ -21,7 +21,7 @@ def cli():
 @cli.command(name="authenticate")
 @click.argument("user")
 @click.option(
-    "--auth-mode", "-m", default="notebook", help="The authentication mode to use."
+    "--auth-mode", "-m", default="localhost", help="The authentication mode to use."
 )
 def authenticate_command(user: str, auth_mode: str):
     """Authenticate USER and store their credentials."""
@@ -31,7 +31,7 @@ def authenticate_command(user: str, auth_mode: str):
             click.echo("Cancelling.\n")
             return
 
-    authenticate(user, auth_mode)
+    authenticate(user, auth_mode=auth_mode)
     click.echo(f"\nAuthenticated `{user}`!\n")
     click.echo(f"* Run `eeauth activate {user}` to set a new default user.\n")
 


### PR DESCRIPTION
Closes #18 

For API, we now have no default auth mode and let EE decide. For CLI, we use localhost since it's faster than notebook. That option was added in 0.1.317, so we pin accordingly.